### PR TITLE
V0.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) wit
 the exception that the versions 0.*.* may have breaking changes in minor versions.
 
 ## [0.4.1]
+
+### Changed
+- `qname` attribute of `QName` is now called `qstr` (breaking change).
+
 ### Fixed
 - Fixed default value of optional parameter in `export_for_excel` method of
   `Journal` class to be `None` instead of `[]`.
+- Parameter `remove_delimiter_from` of `read_bank_csv` now correctly accepts a string.
+
+## Add
+- `acc_qname` attribute or `Posting`, `RPosting`, `BAssertion` can now also be
+  set using a simple string. Same for `qname` attribute of `Account`.
 
 ## [0.4.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with
 the exception that the versions 0.*.* may have breaking changes in minor versions.
 
+## [0.4.1]
+### Fixed
+- Fixed default value of optional parameter in `export_for_excel` method of
+  `Journal` class to be `None` instead of `[]`.
+
 ## [0.4.0]
 ### Changed
 - Major refactoring of the library. Most classes have changed and the API is not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "brightsidebudget"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
   { name="Vincent Archambault-B", email="vincentarchambault@icloud.com" },
 ]

--- a/src/brightsidebudget/account.py
+++ b/src/brightsidebudget/account.py
@@ -25,9 +25,9 @@ class QName():
             raise ValueError("Empty element in qname.")
 
     @property
-    def qname(self) -> str:
+    def qstr(self) -> str:
         """
-        The qualified name.
+        The qualified name as a string.
         """
         return self._qname
 
@@ -96,7 +96,8 @@ class Account():
     An Account represents a single financial entity where transactions occur.
     It is basically a QName with optional tags.
     """
-    def __init__(self, *, qname: Union[QName, str], tags: dict[str, str] = None):
+    def __init__(self, *, qname: Union[QName, str],
+                 tags: Union[dict[str, str], None] = None):
         self._qname = qname if isinstance(qname, QName) else QName(qname)
         self._tags = tags or {}
 
@@ -106,6 +107,13 @@ class Account():
         The qualified name of the account.
         """
         return self._qname
+
+    @qname.setter
+    def qname(self, value: Union[QName, str]):
+        if isinstance(value, QName):
+            self._qname = value
+        else:
+            self._qname = QName(value)
 
     @property
     def tags(self) -> dict[str, str]:

--- a/src/brightsidebudget/bank_import.py
+++ b/src/brightsidebudget/bank_import.py
@@ -16,11 +16,15 @@ class BankCsv():
     Configuration for importing bank transactions from a CSV file.
     """
     def __init__(self, *, file: str, qname: Union[QName, str], date_col: str,
-                 amount_col: Union[str, None] = None, amount_in_col: Union[str, None] = None,
-                 amount_out_col: Union[str, None] = None, stmt_desc_cols: list[str] = None,
+                 amount_col: Union[str, None] = None,
+                 amount_in_col: Union[str, None] = None,
+                 amount_out_col: Union[str, None] = None,
+                 stmt_desc_cols: Union[list[str], None] = None,
                  stmt_date_col: Union[str, None] = None,
-                 remove_delimiter_from: Union[str, list[str]] = None,
-                 skiprows: int = 0, dictreader_args: dict = None, encoding: str = "utf-8"):
+                 remove_delimiter_from: Union[str, list[str], None] = None,
+                 skiprows: int = 0,
+                 dictreader_args: Union[dict[str, str], None] = None,
+                 encoding: str = "utf-8"):
         if amount_col is not None and (amount_in_col is not None or amount_out_col is not None):
             raise ValueError("amount_col cannot be used with amount_in_col or amount_out_col.")
         if amount_col is None and (amount_in_col is None or amount_out_col is None):
@@ -35,7 +39,10 @@ class BankCsv():
         self.amount_out_col = amount_out_col
         self.stmt_desc_cols = stmt_desc_cols or []
         self.stmt_date_col = stmt_date_col
-        self.remove_delimiter_from = remove_delimiter_from or []
+        if isinstance(remove_delimiter_from, str):
+            self.remove_delimiter_from = [remove_delimiter_from]
+        else:
+            self.remove_delimiter_from = remove_delimiter_from or []
         self.skiprows = skiprows
         self.dictreader_args = dictreader_args or {}
 

--- a/src/brightsidebudget/bassertion.py
+++ b/src/brightsidebudget/bassertion.py
@@ -11,8 +11,19 @@ class BAssertion():
     """
     def __init__(self, *, date: date, acc_qname: Union[QName, str], balance: Decimal):
         self.date = date
-        self.acc_qname = acc_qname if isinstance(acc_qname, QName) else QName(acc_qname)
+        self._acc_qname = acc_qname if isinstance(acc_qname, QName) else QName(acc_qname)
         self.balance = balance
+
+    @property
+    def acc_qname(self) -> QName:
+        return self._acc_qname
+
+    @acc_qname.setter
+    def acc_qname(self, value: Union[QName, str]):
+        if isinstance(value, QName):
+            self._acc_qname = value
+        else:
+            self._acc_qname = QName(value)
 
     def __str__(self):
         return f'BAssertion {self.date} {self.acc_qname} {self.balance}'

--- a/src/brightsidebudget/journal.py
+++ b/src/brightsidebudget/journal.py
@@ -480,7 +480,7 @@ class Journal():
                          file: str = "txns.csv",
                          use_short_qname: bool = True,
                          encoding="utf8",
-                         aliases: list[tuple[str, dict[QName, QName]]] = [],
+                         aliases: list[tuple[str, dict[QName, QName]]] | None = None,
                          today: Union[date, None] = None,
                          first_fiscal_month: int = 1):
         """
@@ -488,6 +488,9 @@ class Journal():
         """
         if today is None:
             today = date.today()
+
+        if aliases is None:
+            aliases = []
 
         ps = [p.copy() for p in self.postings]
         for p in ps:

--- a/src/brightsidebudget/journal.py
+++ b/src/brightsidebudget/journal.py
@@ -480,7 +480,7 @@ class Journal():
                          file: str = "txns.csv",
                          use_short_qname: bool = True,
                          encoding="utf8",
-                         aliases: list[tuple[str, dict[QName, QName]]] | None = None,
+                         aliases: Union[list[tuple[str, dict[QName, QName]]], None] = None,
                          today: Union[date, None] = None,
                          first_fiscal_month: int = 1):
         """
@@ -505,7 +505,7 @@ class Journal():
                     p.tags["Txn type"] = "budget"
                     ps.append(p)
 
-        ps.sort(key=lambda p: (p.date, p.txnid, p.acc_qname.qname))
+        ps.sort(key=lambda p: (p.date, p.txnid, p.acc_qname.qstr))
 
         def alias(qname: QName, d: dict[QName, QName]) -> QName:
             if qname in d:
@@ -604,7 +604,7 @@ class Journal():
             file = filefunc(t)
             if file not in file_dict:
                 file_dict[file] = []
-            ps = sorted(t.postings, key=lambda x: x.acc_qname.qname)
+            ps = sorted(t.postings, key=lambda x: x.acc_qname.qstr)
             file_dict[file].extend(ps)
 
         if renumber:

--- a/src/brightsidebudget/posting.py
+++ b/src/brightsidebudget/posting.py
@@ -12,15 +12,27 @@ class Posting():
     """
     def __init__(self, *, txnid: int, date: date, acc_qname: Union[QName, str], amount: Decimal,
                  comment: Union[str, None] = None, stmt_desc: Union[str, None] = None,
-                 stmt_date: Union[date, None] = None, tags: dict[str, str] = None):
+                 stmt_date: Union[date, None] = None,
+                 tags: Union[dict[str, str], None] = None):
         self.txnid = txnid
         self.date = date
-        self.acc_qname = acc_qname if isinstance(acc_qname, QName) else QName(acc_qname)
+        self._acc_qname = acc_qname if isinstance(acc_qname, QName) else QName(acc_qname)
         self.amount = amount
         self.comment = comment
         self.stmt_desc = stmt_desc
         self.stmt_date = stmt_date or date
         self.tags = tags or {}
+
+    @property
+    def acc_qname(self) -> QName:
+        return self._acc_qname
+
+    @acc_qname.setter
+    def acc_qname(self, value: Union[QName, str]):
+        if isinstance(value, QName):
+            self._acc_qname = value
+        else:
+            self._acc_qname = QName(value)
 
     def tag(self, key: str) -> Union[str, None]:
         return self.tags.get(key, None)
@@ -97,7 +109,7 @@ class RPosting():
                  frequency: Union[str, None] = None, interval: Union[int, None] = None,
                  count: Union[int, None] = None, until: Union[date, None] = None):
         self.start = start
-        self.acc_qname = acc_qname if isinstance(acc_qname, QName) else QName(acc_qname)
+        self._acc_qname = acc_qname if isinstance(acc_qname, QName) else QName(acc_qname)
         self.amount = amount
         self.comment = comment
         self.tags = tags or {}
@@ -133,6 +145,17 @@ class RPosting():
         else:
             r = rrule(self.frequency, dtstart=s, interval=self.interval)
         self._rrule = r
+
+    @property
+    def acc_qname(self) -> QName:
+        return self._acc_qname
+
+    @acc_qname.setter
+    def acc_qname(self, value: Union[QName, str]):
+        if isinstance(value, QName):
+            self._acc_qname = value
+        else:
+            self._acc_qname = QName(value)
 
     def postings_for_month(self, month: date) -> list[Posting]:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,11 @@ def bank_checking_file() -> str:
 
 
 @pytest.fixture()
+def bank_checking_bad_delimiter() -> str:
+    return "tests/fixtures/bank_checking_bad_delimiter.csv"
+
+
+@pytest.fixture()
 def bassertions_file() -> str:
     return "tests/fixtures/bassertions.csv"
 

--- a/tests/fixtures/bank_checking_bad_delimiter.csv
+++ b/tests/fixtures/bank_checking_bad_delimiter.csv
@@ -1,0 +1,6 @@
+Date,Description,Category,Debit,Credit,Balance
+2021-01-06,"Super market","Food",140,0,3270
+2021-01-05,"Electricity Inc","Utilities",50,0,3410
+2021-01-02,An unquoted, comma,"Debit transfert",1000,0,3460
+2021-01-02,"ABC Corp","Uncategorized",0,2000,4460
+2021-01-02,"Super market","Food",40,0,2460

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,10 +1,11 @@
 import pytest
 from brightsidebudget import QName
+from brightsidebudget.account import Account
 
 
 def test_qname():
     qname = QName("A:B:C")
-    assert qname.qname == "A:B:C"
+    assert qname.qstr == "A:B:C"
     assert qname.qlist == ["A", "B", "C"]
     assert qname.depth == 3
     assert qname.parent == QName("A:B")
@@ -30,3 +31,11 @@ def test_qname():
 
     with pytest.raises(ValueError):
         QName([])
+
+
+def test_account():
+    acc = Account(qname="A:B:C")
+
+    # Change name using string
+    acc.qname = "D:E:F"
+    assert acc.qname == QName("D:E:F")

--- a/tests/test_bassertion.py
+++ b/tests/test_bassertion.py
@@ -8,3 +8,7 @@ def test_bassertion():
     b2 = BAssertion(date=date(2021, 1, 1), acc_qname=QName("A:B:C"), balance=Decimal("100.00"))
     assert isinstance(b1.acc_qname, QName)
     assert b1.acc_qname == b2.acc_qname
+
+    # Change name using string
+    b1.acc_qname = "D:E:F"
+    assert b1.acc_qname == QName("D:E:F")

--- a/tests/test_importation.py
+++ b/tests/test_importation.py
@@ -1,0 +1,34 @@
+from brightsidebudget import Journal, import_bank_csv, BankCsv
+from brightsidebudget.posting import Posting, Txn
+
+
+def classifier(p: Posting) -> Txn:
+    p2 = p.copy()
+    p2.amount = -p.amount
+    if p.stmt_desc == "Super market":
+        p2.acc_qname = "Food"
+        return Txn([p, p2])
+    else:
+        p2.acc_qname = "Expenses:Other"
+        return Txn([p, p2])
+
+
+def test_read_bank_csv(bank_checking_file, accounts_file, txns_file):
+    bank = BankCsv(file=bank_checking_file, qname="Checking", date_col="Date",
+                   amount_in_col="Credit", amount_out_col="Debit",
+                   stmt_desc_cols=["Description"])
+    j = Journal.from_csv(accounts=accounts_file, postings=txns_file)
+    txns = import_bank_csv(j, bank, classifier)
+    assert len(txns) == 4
+    assert txns[0].postings[0].acc_qname.qstr == "Assets:Checking"
+    assert txns[0].postings[1].acc_qname.qstr == "Expenses:Food"
+
+
+def test_remove_delemiter_from(bank_checking_bad_delimiter, accounts_file, txns_file):
+    bank = BankCsv(file=bank_checking_bad_delimiter, qname="Checking", date_col="Date",
+                   amount_in_col="Credit", amount_out_col="Debit",
+                   remove_delimiter_from="An unquoted, comma",
+                   stmt_desc_cols=["Description"])
+    j = Journal.from_csv(accounts=accounts_file, postings=txns_file)
+    txns = import_bank_csv(j, bank, classifier)
+    assert len(txns) == 4

--- a/tests/test_posting.py
+++ b/tests/test_posting.py
@@ -12,6 +12,10 @@ def test_posting():
     assert isinstance(p1.acc_qname, QName)
     assert p1.acc_qname == p2.acc_qname
 
+    # Change name using string
+    p1.acc_qname = "D:E:F"
+    assert p1.acc_qname == QName("D:E:F")
+
 
 def test_txn():
     p1 = Posting(txnid=1, date=date(2021, 1, 1), acc_qname="A:A1", amount=Decimal("100.00"))
@@ -71,3 +75,7 @@ def test_rposting():
     assert ps[0].date == date(2021, 1, 1)
     assert ps[1].date == date(2021, 3, 1)
     assert ps[2].date == date(2021, 5, 1)
+
+    # Change name using string
+    r1.acc_qname = "D:E:F"
+    assert r1.acc_qname == QName("D:E:F")


### PR DESCRIPTION
### Changed
- `qname` attribute of `QName` is now called `qstr` (breaking change).

### Fixed
- Fixed default value of optional parameter in `export_for_excel` method of
  `Journal` class to be `None` instead of `[]`.
- Parameter `remove_delimiter_from` of `read_bank_csv` now correctly accepts a string.

## Add
- `acc_qname` attribute or `Posting`, `RPosting`, `BAssertion` can now also be
  set using a simple string. Same for `qname` attribute of `Account`.