### PR TITLE
Add short_qname attribute to account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with
 the exception that the versions 0.*.* may have breaking changes in minor versions.
 
+## [0.4.6]
+### Added
+- Added `short_qname` attribute to `Account` to limit the shortest qualified
+  name of an account. This is a breaking change since the `qname` attribute now
+  has to be modified with `update_qname` method.
+
 ## [0.4.5]
 ### Fixed
 - Fixed `adjust_for_bassertion` when called with a child parameter with a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "brightsidebudget"
-version = "0.4.5"
+version = "0.4.6"
 authors = [
   { name="Vincent Archambault-B", email="vincentarchambault@icloud.com" },
 ]

--- a/src/brightsidebudget/account.py
+++ b/src/brightsidebudget/account.py
@@ -98,11 +98,19 @@ class QName():
 class Account():
     """
     An Account represents a single financial entity where transactions occur.
-    It is basically a QName with optional tags.
+    It is basically a QName with optional tags and information.
+
+    short_qname is the shortest version of the qname that can be used in reports.
+    For example, if the qname is "Assets:Savings:Capital gain" and the short_qname
+    is "Savings:Capital gain", then the account will never be printed as "Capital gain"
+    in reports even if this name is unambiguous.
     """
     def __init__(self, *, qname: Union[QName, str],
+                 short_qname: Union[QName, str, None] = None,
                  tags: Union[dict[str, str], None] = None):
-        self._qname = qname if isinstance(qname, QName) else QName(qname)
+        self._qname = None
+        self._short_qname = None
+        self.update_qname(qname, short_qname)
         self._tags = tags or {}
 
     @property
@@ -112,12 +120,31 @@ class Account():
         """
         return self._qname
 
-    @qname.setter
-    def qname(self, value: Union[QName, str]):
-        if isinstance(value, QName):
-            self._qname = value
+    @property
+    def short_qname(self) -> QName:
+        """
+        The shortest qualified name of the account to be used in reports.
+        """
+        return self._short_qname
+
+    def update_qname(self, qname: Union[QName, str],
+                     short_qname: Union[QName, str, None] = None):
+        self._qname = qname if isinstance(qname, QName) else QName(qname)
+        if short_qname is None:
+            self._short_qname = QName(self._qname.qlist[-1])
+        elif isinstance(short_qname, str):
+            self._short_qname = QName(short_qname)
         else:
-            self._qname = QName(value)
+            self._short_qname = short_qname
+
+        s = self._short_qname
+        if s.depth > self._qname.depth:
+            raise ValueError("Short qname must be shorter or equal to the qname.")
+        if self._qname.qlist[-s.depth:] != s.qlist:
+            raise ValueError("Short qname must be a suffix of the qname.")
+
+    def update_short_qname(self, short_qname: Union[QName, str]):
+        self.update_qname(self._qname, short_qname)
 
     @property
     def tags(self) -> dict[str, str]:

--- a/src/brightsidebudget/journal.py
+++ b/src/brightsidebudget/journal.py
@@ -49,7 +49,10 @@ class Journal():
         """
         if isinstance(qname, str):
             qname = QName(qname=qname)
-        return self.short_qname_dict[qname]
+        try:
+            return self.short_qname_dict[qname]
+        except KeyError as e:
+            raise ValueError(f'Account {qname} does not exist or is ambiguous') from e
 
     def has_account(self, qname: Union[QName, str], full_qname: bool = False) -> bool:
         """
@@ -66,20 +69,27 @@ class Journal():
         else:
             return qname in self.short_qname_dict
 
-    def short_qname(self, full_qname: Union[QName, str]) -> QName:
+    def short_qname(self, qname: Union[QName, str]) -> QName:
         """
-        Returns the shortest qualified name that uniquely identifies the account.
+        Returns the shortest qualified name that uniquely identifies the account and
+        respects the short_qname attribute of the account.
+
+        The qname must be a valid qualified name.
         """
-        if isinstance(full_qname, str):
-            full_qname = QName(qname=full_qname)
-        ls = full_qname._qlist
+        acc = self.account(qname)
+        ls = acc.qname.qlist
         # We try all possible short names starting from shortest to longest
         for i in range(len(ls) - 1, -1, -1):
             short_name = QName(ls[i:])
-            if (short_name in self.short_qname_dict
-               and self.short_qname_dict[short_name].qname == full_qname):
-                return short_name
-        raise ValueError(f'Account {full_qname} does not exist or is ambiguous')
+            if short_name not in self.short_qname_dict:
+                continue
+            # If the short name matched, then we know it is this account
+            # because ambiguous short names are not allowed
+            if short_name.depth < acc.short_qname.depth:
+                # The short name is shorter than the account's short name
+                # We respect the account's short name
+                return acc.short_qname
+            return short_name
 
     def full_qname(self, qname: Union[QName, str]) -> QName:
         """
@@ -282,9 +292,14 @@ class Journal():
             reader = csv.DictReader(f)
             for row in reader:
                 qname = row['Compte']
+                if 'Compte nom court' in row:
+                    short_qname = row['Compte nom court']
+                else:
+                    short_qname = None
                 d = row.copy()
-                d.pop('Compte')
-                accs.append(Account(qname=qname, tags=d))
+                for x in ['Compte', 'Compte nom court']:
+                    d.pop('Compte', None)
+                accs.append(Account(qname=qname, tags=d, short_qname=short_qname))
         j.add_accounts(accs)
 
         ps: list[Posting] = []

--- a/tests/fixtures/accounts.csv
+++ b/tests/fixtures/accounts.csv
@@ -1,4 +1,4 @@
-Compte,Numéro
+Compte,Numéro,Compte nom court
 Assets,1000
 Assets:Checking,1005
 Assets:Savings,1006
@@ -15,4 +15,4 @@ Expenses,5000
 Expenses:Utilities,5005
 Expenses:Rent,5006
 Expenses:Food,5007
-Expenses:Other,5008
+Expenses:Other,5008,Expenses:Other

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -37,7 +37,23 @@ def test_qname():
 
 def test_account():
     acc = Account(qname="A:B:C")
+    assert acc.qname == QName("A:B:C")
+    assert acc.short_qname == QName("C")
 
-    # Change name using string
-    acc.qname = "D:E:F"
+    # Change name
+    acc.update_qname("D:E:F")
     assert acc.qname == QName("D:E:F")
+    assert acc.short_qname == QName("F")
+
+    acc.update_qname("D:E:F", short_qname="E:F")
+    assert acc.qname == QName("D:E:F")
+    assert acc.short_qname == QName("E:F")
+
+    acc.update_short_qname("D:E:F")
+    assert acc.qname == QName("D:E:F")
+    assert acc.short_qname == QName("D:E:F")
+
+    with pytest.raises(ValueError):
+        Account(qname="A:B:C", short_qname="X:C")
+    with pytest.raises(ValueError):
+        Account(qname="A:B:C", short_qname="A:B")

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -67,6 +67,16 @@ def test_adjust_for_bassertion_child(accounts_file, txns_file):
     assert len(j.postings) == 10
 
 
+def test_short_qname(accounts_file, txns_file):
+    j = Journal.from_csv(accounts=accounts_file, postings=txns_file)
+    assert j.short_qname('Assets:Checking').qstr == 'Checking'
+    assert j.short_qname('Checking').qstr == 'Checking'
+    assert j.short_qname('Assets').qstr == 'Assets'
+    assert j.short_qname('Other').qstr == 'Expenses:Other'  # Restricted by accounts file
+    assert j.short_qname('Expenses:Other').qstr == 'Expenses:Other'
+    assert j.short_qname('Expenses:Food').qstr == 'Food'
+
+
 def test_empty_journal():
     j = Journal()
     assert len(j.accounts) == 0


### PR DESCRIPTION
### Added
- Added `short_qname` attribute to `Account` to limit the shortest qualified
  name of an account. This is a breaking change since the `qname` attribute now
  has to be modified with `update_qname` method.