### PR TITLE
Fix from_csv with empty short qname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with
 the exception that the versions 0.*.* may have breaking changes in minor versions.
 
+## [0.4.7]
+### Fixed
+- `from_csv` method of `Journal` now correctly reads empty `short_qname`.
+
 ## [0.4.6]
 ### Added
 - Added `short_qname` attribute to `Account` to limit the shortest qualified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "brightsidebudget"
-version = "0.4.6"
+version = "0.4.7"
 authors = [
   { name="Vincent Archambault-B", email="vincentarchambault@icloud.com" },
 ]

--- a/src/brightsidebudget/journal.py
+++ b/src/brightsidebudget/journal.py
@@ -293,7 +293,7 @@ class Journal():
             for row in reader:
                 qname = row['Compte']
                 if 'Compte nom court' in row:
-                    short_qname = row['Compte nom court']
+                    short_qname = empty_is_none(row['Compte nom court'])
                 else:
                     short_qname = None
                 d = row.copy()

--- a/tests/fixtures/accounts.csv
+++ b/tests/fixtures/accounts.csv
@@ -1,18 +1,18 @@
 Compte,Numéro,Compte nom court
-Assets,1000
-Assets:Checking,1005
-Assets:Savings,1006
-Assets:House,1200
-Liabilities,2000
-Liabilities:Credit card,2005
-Liabilities:Long term debt,2050
-Liabilities:Long term debt:Mortgage,2051
-Equity,3000
-Equity:Opening balance,Equity
-Revenue,4000
-Revenue:Salary,4005
-Expenses,5000
-Expenses:Utilities,5005
-Expenses:Rent,5006
-Expenses:Food,5007
+Assets,1000,
+Assets:Checking,1005,
+Assets:Savings,1006,
+Assets:House,1200,
+Liabilities,2000,
+Liabilities:Credit card,2005,
+Liabilities:Long term debt,2050,
+Liabilities:Long term debt:Mortgage,2051,
+Equity,3000,
+Equity:Opening balance,3005,
+Revenue,4000,
+Revenue:Salary,4005,
+Expenses,5000,
+Expenses:Utilities,5005,
+Expenses:Rent,5006,
+Expenses:Food,5007,
 Expenses:Other,5008,Expenses:Other


### PR DESCRIPTION
### Fixed
- `from_csv` method of `Journal` now correctly reads empty `short_qname`.