### PR TITLE
V0.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with
 the exception that the versions 0.*.* may have breaking changes in minor versions.
 
+## [0.5.4]
+### Fixed
+- `Account` class `copy` method now correctly copies the `short_qname` attribute.
+
 ## [0.5.3]
 ### Fixed
 - Fixed importation of empty strings as tags in `from_csv` method of `Journal`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) wit
 the exception that the versions 0.*.* may have breaking changes in minor versions.
 
 ## [0.5.4]
-### Fixed
-- `Account` class `copy` method now correctly copies the `short_qname` attribute.
+### Removed
+- Removed `Account` class `short_qname` attribute. The `to_polars` and
+  `write_txns` methods of `Journal` class now uses a `short_qname_lenght`
+  parameter to limit the shortest qualified name of an account.
 
 ## [0.5.3]
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "brightsidebudget"
-version = "0.5.3"
+version = "0.5.4"
 authors = [
   { name="Vincent Archambault-B", email="vincentarchambault@icloud.com" },
 ]

--- a/src/brightsidebudget/account.py
+++ b/src/brightsidebudget/account.py
@@ -34,7 +34,7 @@ class QName():
     @property
     def qlist(self) -> list[str]:
         """
-        The qualified name as a list of name.
+        The qualified name as a list of name. The list is a new copy.
         """
         return self._qlist.copy()
 
@@ -48,7 +48,7 @@ class QName():
     @property
     def depth(self) -> int:
         """
-        The depth of the qualified name.
+        The depth of the qualified name. Equals to the number of elements in the QName.
         """
         return len(self._qlist)
 
@@ -97,20 +97,14 @@ class QName():
 
 class Account():
     """
-    An Account represents a single financial entity where transactions occur.
-    It is basically a QName with optional tags and information.
-
-    short_qname is the shortest version of the qname that can be used in reports.
-    For example, if the qname is "Assets:Savings:Capital gain" and the short_qname
-    is "Savings:Capital gain", then the account will never be printed as "Capital gain"
-    in reports even if this name is unambiguous.
+    An Account represents a single financial entity where transactions occur. It
+    is basically a QName with optional tags.
     """
     def __init__(self, *, qname: Union[QName, str],
-                 short_qname: Union[QName, str, None] = None,
                  tags: Union[dict[str, str], None] = None):
-        self._qname = None
-        self._short_qname = None
-        self.update_qname(qname, short_qname)
+        if isinstance(qname, str):
+            qname = QName(qname)
+        self._qname = qname
         self._tags = tags or {}
 
     @property
@@ -120,38 +114,18 @@ class Account():
         """
         return self._qname
 
-    @property
-    def short_qname(self) -> QName:
-        """
-        The shortest qualified name of the account to be used in reports.
-        """
-        return self._short_qname
-
-    def update_qname(self, qname: Union[QName, str],
-                     short_qname: Union[QName, str, None] = None):
-        self._qname = qname if isinstance(qname, QName) else QName(qname)
-        if short_qname is None:
-            self._short_qname = QName(self._qname.qlist[-1])
-        elif isinstance(short_qname, str):
-            self._short_qname = QName(short_qname)
-        else:
-            self._short_qname = short_qname
-
-        s = self._short_qname
-        if s.depth > self._qname.depth:
-            raise ValueError("Short qname must be shorter or equal to the qname.")
-        if self._qname.qlist[-s.depth:] != s.qlist:
-            raise ValueError("Short qname must be a suffix of the qname.")
-
-    def update_short_qname(self, short_qname: Union[QName, str]):
-        self.update_qname(self._qname, short_qname)
+    @qname.setter
+    def qname(self, value: Union[QName, str]):
+        if isinstance(value, str):
+            value = QName(value)
+        self._qname = value
 
     @property
     def tags(self) -> dict[str, str]:
         return self._tags
 
     def copy(self) -> 'Account':
-        return Account(qname=self._qname, tags=self._tags.copy(), short_qname=self._short_qname)
+        return Account(qname=self._qname, tags=self._tags.copy())
 
     def tag(self, key: str) -> Union[str, None]:
         return self._tags.get(key, None)

--- a/src/brightsidebudget/account.py
+++ b/src/brightsidebudget/account.py
@@ -151,7 +151,7 @@ class Account():
         return self._tags
 
     def copy(self) -> 'Account':
-        return Account(qname=self._qname, tags=self._tags.copy())
+        return Account(qname=self._qname, tags=self._tags.copy(), short_qname=self._short_qname)
 
     def tag(self, key: str) -> Union[str, None]:
         return self._tags.get(key, None)

--- a/src/brightsidebudget/journal.py
+++ b/src/brightsidebudget/journal.py
@@ -70,27 +70,24 @@ class Journal():
         else:
             return qname in self.short_qname_dict
 
-    def short_qname(self, qname: Union[QName, str]) -> QName:
+    def short_qname(self, qname: Union[QName, str],
+                    min_length: int = 1) -> QName:
         """
-        Returns the shortest qualified name that uniquely identifies the account and
-        respects the short_qname attribute of the account.
+        Returns the shortest qualified name that uniquely identifies the
+        account. The qname must be a valid qualified name.
+        """
+        if min_length < 1:
+            raise ValueError('min_length must be greater than 0')
 
-        The qname must be a valid qualified name.
-        """
-        acc = self.account(qname)
-        ls = acc.qname.qlist
         # We try all possible short names starting from shortest to longest
-        for i in range(len(ls) - 1, -1, -1):
-            short_name = QName(ls[i:])
-            if short_name not in self.short_qname_dict:
-                continue
-            # If the short name matched, then we know it is this account
-            # because ambiguous short names are not allowed
-            if short_name.depth < acc.short_qname.depth:
-                # The short name is shorter than the account's short name
-                # We respect the account's short name
-                return acc.short_qname
-            return short_name
+        # We know the full qname is unique, so we will find a match
+        acc = self.account(qname)
+        qlist = acc.qname._qlist
+        min_length = min(min_length, len(qlist))
+        for i in range(min_length, len(qlist) + 1):
+            short_name = QName(qlist[-i:])
+            if short_name in self.short_qname_dict:
+                return short_name
 
     def full_qname(self, qname: Union[QName, str]) -> QName:
         """
@@ -128,12 +125,17 @@ class Journal():
                 raise ValueError(f'Parent account {parent} does not exist or is ambiguous')
 
             self.full_qname_set.add(a.qname)
-            # Update qname_dict. This dict also contains shorted names
             self.accounts.append(a)
+
+            # Now we need to update the short_qname_dict.
+            # We know the full qname is unique, so let's add it
             self.short_qname_dict[a.qname] = a
-            ls = a.qname._qlist
-            for idx in range(1, len(ls)):
-                short_name = QName(ls[idx:])
+
+            # But the short qname may not be unique. We go from the shortest
+            # qname to just before the full qname, removing any ambiguity.
+            qlist = a.qname.qlist
+            for idx in range(1, len(qlist)):
+                short_name = QName(qlist[-idx:])
                 if short_name in self.full_qname_set:
                     # Cannot overwrite a full qname
                     continue
@@ -166,7 +168,7 @@ class Journal():
                 elif p.txnid in self.txns_dict:
                     raise ValueError(f'Transaction {p.txnid} already exists')
 
-                if p.acc_qname not in self.short_qname_dict:
+                if not self.has_account(p.acc_qname):
                     msg = f'Txn {p.txnid}: Account {p.acc_qname} does not exist or is ambiguous'
                     raise ValueError(msg)
 
@@ -199,7 +201,7 @@ class Journal():
             bassertions = [b.copy() for b in bassertions]
 
         for b in bassertions:
-            if b.acc_qname not in self.short_qname_dict:
+            if not self.has_account(b.acc_qname):
                 raise ValueError(f'Account {b.acc_qname} does not exist or is ambiguous')
 
             # Update to full qname
@@ -218,7 +220,7 @@ class Journal():
             targets = [t.copy() for t in targets]
 
         for t in targets:
-            if t.acc_qname not in self.short_qname_dict:
+            if not self.has_account(t.acc_qname):
                 raise ValueError(f'Account {t.acc_qname} does not exist or is ambiguous')
             if not self.is_leaf_account(t.acc_qname):
                 raise ValueError(f'Account {t.acc_qname} is not a leaf account')
@@ -293,17 +295,13 @@ class Journal():
             reader = csv.DictReader(f)
             for row in reader:
                 qname = row['Account']
-                if 'Account short name' in row:
-                    short_qname = empty_is_none(row['Account short name'])
-                else:
-                    short_qname = None
                 d = row.copy()
-                for x in ['Account', 'Account short name']:
+                for x in ['Account']:
                     d.pop(x, None)
                 for k, v in list(d.items()):
                     if v is None or v.strip() == '':
                         d.pop(k)
-                accs.append(Account(qname=qname, tags=d, short_qname=short_qname))
+                accs.append(Account(qname=qname, tags=d))
         j.add_accounts(accs)
 
         ps: list[Posting] = []
@@ -522,13 +520,16 @@ class Journal():
             accs = self.accounts
         return list({k for a in accs for k in a.tags.keys()})
 
-    def to_polars(self, ps: Union[list[Posting], None] = None) -> pl.DataFrame:
+    def to_polars(self,
+                  ps: Union[list[Posting], None] = None,
+                  short_qname_length: Union[dict[QName, int], None] = None) -> pl.DataFrame:
         """
         Returns a polars DataFrame with the postings, including all tags from
         both the postings and the accounts. In the case of a tag name conflict,
         the account tag is suffix with '_acc'.
 
         If `ps` is None, the function uses all the postings in the journal.
+        short_qname_lenght: A dictionary that maps a QName to the minimum length
 
         The columns are:
             - Txn: Transaction ID
@@ -543,6 +544,8 @@ class Journal():
             - All tags from the postings
             - All tags from the accounts
         """
+        if short_qname_length is None:
+            short_qname_length = {}
         if ps is None:
             ps = self.postings
         known_keys = set(self.all_postings_tags(ps))
@@ -566,11 +569,15 @@ class Journal():
 
         data = []
         for p in ps:
+            if p.acc_qname in short_qname_length:
+                short_qname = self.short_qname(p.acc_qname, short_qname_length[p.acc_qname])
+            else:
+                short_qname = self.short_qname(p.acc_qname)
             d = {
                 'Txn': p.txnid,
                 'Date': p.date,
                 'Account': p.acc_qname.qstr,
-                'Account short name': self.short_qname(p.acc_qname).qstr,
+                'Account short name': short_qname.qstr,
                 'Amount': float(p.amount),
                 'Comment': p.comment,
                 'Stmt date': p.stmt_date,
@@ -603,7 +610,8 @@ class Journal():
     def write_txns(self, *,
                    txns: Union[list[Txn], None] = None,
                    filefunc: Union[str, Callable[[Txn], str]] = "txns.csv",
-                   use_short_qname: bool = True,
+                   use_short_qname: bool = False,
+                   short_qname_length: Union[dict[QName, int], None] = None,
                    renumber: bool = False,
                    encoding="utf8"):
         """
@@ -650,7 +658,11 @@ class Journal():
                         txnid = p.txnid
                     row = [txnid, p.date]
                     if use_short_qname:
-                        row.append(self.short_qname(p.acc_qname))
+                        if p.acc_qname in short_qname_length:
+                            short = self.short_qname(p.acc_qname, short_qname_length[p.acc_qname])
+                        else:
+                            short = self.short_qname(p.acc_qname)
+                        row.append(short)
                     else:
                         row.append(p.acc_qname)
                     row += [p.amount, p.stmt_date, p.comment, p.stmt_desc]

--- a/tests/fixtures/accounts.csv
+++ b/tests/fixtures/accounts.csv
@@ -1,18 +1,18 @@
-Account,Number,Account short name,Tag 1
-Assets,1000,,Actifs
-Assets:Checking,1005,,
-Assets:Savings,1006,,
-Assets:House,1200,,
-Liabilities,2000,,Passifs
-Liabilities:Credit card,2005,,
-Liabilities:Long term debt,2050,,
-Liabilities:Long term debt:Mortgage,2051,,
-Equity,3000,,Capitaux propres
-Equity:Opening balance,3005,,
-Revenue,4000,,Revenus
-Revenue:Salary,4005,,
-Expenses,5000,,Dépenses
-Expenses:Utilities,5005,,
-Expenses:Rent,5006,,
-Expenses:Food,5007,,
-Expenses:Other,5008,Expenses:Other
+Account,Number,Tag 1
+Assets,1000,Actifs
+Assets:Checking,1005,
+Assets:Savings,1006,
+Assets:House,1200,
+Liabilities,2000,Passifs
+Liabilities:Credit card,2005,
+Liabilities:Long term debt,2050,
+Liabilities:Long term debt:Mortgage,2051,
+Equity,3000,Capitaux propres
+Equity:Opening balance,3005,
+Revenue,4000,Revenus
+Revenue:Salary,4005,
+Expenses,5000,Dépenses
+Expenses:Utilities,5005,
+Expenses:Rent,5006,
+Expenses:Food,5007,
+Expenses:Other,5008,

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -38,30 +38,10 @@ def test_qname():
 def test_account():
     acc = Account(qname="A:B:C")
     assert acc.qname == QName("A:B:C")
-    assert acc.short_qname == QName("C")
 
     acc2 = acc.copy()
     assert acc2.qname == QName("A:B:C")
-    assert acc2.short_qname == QName("C")
 
     # Change name
-    acc.update_qname("D:E:F")
+    acc.qname = "D:E:F"
     assert acc.qname == QName("D:E:F")
-    assert acc.short_qname == QName("F")
-
-    acc.update_qname("D:E:F", short_qname="E:F")
-    assert acc.qname == QName("D:E:F")
-    assert acc.short_qname == QName("E:F")
-
-    acc2 = acc.copy()
-    assert acc2.qname == QName("D:E:F")
-    assert acc2.short_qname == QName("E:F")
-
-    acc.update_short_qname("D:E:F")
-    assert acc.qname == QName("D:E:F")
-    assert acc.short_qname == QName("D:E:F")
-
-    with pytest.raises(ValueError):
-        Account(qname="A:B:C", short_qname="X:C")
-    with pytest.raises(ValueError):
-        Account(qname="A:B:C", short_qname="A:B")

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -40,6 +40,10 @@ def test_account():
     assert acc.qname == QName("A:B:C")
     assert acc.short_qname == QName("C")
 
+    acc2 = acc.copy()
+    assert acc2.qname == QName("A:B:C")
+    assert acc2.short_qname == QName("C")
+
     # Change name
     acc.update_qname("D:E:F")
     assert acc.qname == QName("D:E:F")
@@ -48,6 +52,10 @@ def test_account():
     acc.update_qname("D:E:F", short_qname="E:F")
     assert acc.qname == QName("D:E:F")
     assert acc.short_qname == QName("E:F")
+
+    acc2 = acc.copy()
+    assert acc2.qname == QName("D:E:F")
+    assert acc2.short_qname == QName("E:F")
 
     acc.update_short_qname("D:E:F")
     assert acc.qname == QName("D:E:F")

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,6 +1,9 @@
 from datetime import date
 from decimal import Decimal
+
+import pytest
 from brightsidebudget import Journal, BAssertion
+from brightsidebudget.account import Account
 
 
 def test_from_csv(accounts_file, txns_file, bassertions_file, budget_file):
@@ -73,14 +76,17 @@ def test_adjust_for_bassertion_child(accounts_file, txns_file):
     assert len(j.postings) == 10
 
 
-def test_short_qname(accounts_file, txns_file):
+def test_short_qnames_1(accounts_file, txns_file):
     j = Journal.from_csv(accounts=accounts_file, postings=txns_file)
     assert j.short_qname('Assets:Checking').qstr == 'Checking'
     assert j.short_qname('Checking').qstr == 'Checking'
     assert j.short_qname('Assets').qstr == 'Assets'
-    assert j.short_qname('Other').qstr == 'Expenses:Other'  # Restricted by accounts file
-    assert j.short_qname('Expenses:Other').qstr == 'Expenses:Other'
+    assert j.short_qname('Expenses:Other').qstr == 'Other'
     assert j.short_qname('Expenses:Food').qstr == 'Food'
+
+    assert j.short_qname('Assets:Checking', min_length=2).qstr == 'Assets:Checking'
+    assert j.short_qname('Checking', min_length=2).qstr == 'Assets:Checking'
+    assert j.short_qname('Assets', min_length=2).qstr == 'Assets'
 
 
 def test_empty_journal():
@@ -129,3 +135,19 @@ def test_conflicting_tags(accounts_file, txns_file):
     assert df['Tag 1'].unique().to_list() == ['Conflict']
     assert df['Tag 1_acc'].unique().to_list() == ['Conflict again']
     assert "Tag 1_acc2" in df.columns
+
+
+def test_short_qnames_2():
+    j = Journal()
+    j.add_accounts([Account(qname='Assets'),
+                    Account(qname='Assets:Checking'),
+                    Account(qname='Assets:Checking:Foo'),
+                    Account(qname='Assets:Savings'),
+                    Account(qname='Assets:Savings:Foo')])
+    assert j.short_qname('Assets:Checking:Foo').qstr == 'Checking:Foo'
+    assert j.short_qname('Checking:Foo').qstr == 'Checking:Foo'
+    assert j.short_qname('Assets:Savings:Foo').qstr == 'Savings:Foo'
+    assert j.short_qname('Savings:Foo').qstr == 'Savings:Foo'
+
+    with pytest.raises(ValueError):
+        j.short_qname('Foo')


### PR DESCRIPTION
### Removed
- Removed `Account` class `short_qname` attribute. The `to_polars` and
  `write_txns` methods of `Journal` class now uses a `short_qname_lenght`
  parameter to limit the shortest qualified name of an account.