### PR TITLE
Fixed `short_qname_lenght` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with
 the exception that the versions 0.*.* may have breaking changes in minor versions.
 
+## [0.5.5]
+### Fixed
+- Fixed bug when `short_qname_lenght` parameter of `write_txns` method of `Journal`
+  class was set to None.
+
 ## [0.5.4]
 ### Removed
 - Removed `Account` class `short_qname` attribute. The `to_polars` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "brightsidebudget"
-version = "0.5.4"
+version = "0.5.5"
 authors = [
   { name="Vincent Archambault-B", email="vincentarchambault@icloud.com" },
 ]

--- a/src/brightsidebudget/journal.py
+++ b/src/brightsidebudget/journal.py
@@ -617,6 +617,8 @@ class Journal():
         """
         Write the postings to a one or more CSV files.
         """
+        if short_qname_length is None:
+            short_qname_length = {}
         if txns is None:
             txns = self.txns_dict.values()
 


### PR DESCRIPTION
Fixed bug when `short_qname_lenght` parameter of `write_txns` method of `Journal`
  class was set to None.