### PR TITLE
Fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html) with
 the exception that the versions 0.*.* may have breaking changes in minor versions.
 
+## [0.5.9]
+### Fixed
+- Fixed a typo in the report module. `add_txn_accounts_colum` -> `add_txn_accounts_column`
+
 ## [0.5.8]
 ### Added
 - Add a check to prevent adding duplicate balance assertions in the `Journal` class.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "brightsidebudget"
-version = "0.5.8"
+version = "0.5.9"
 authors = [
   { name="Vincent Archambault-B", email="vincentarchambault@icloud.com" },
 ]

--- a/src/brightsidebudget/report.py
+++ b/src/brightsidebudget/report.py
@@ -92,8 +92,8 @@ def add_relative_month_column(df: pl.DataFrame,
         )
 
 
-def add_txn_accounts_colum(df: pl.DataFrame,
-                           col_name: str = "Txn Accounts") -> pl.DataFrame:
+def add_txn_accounts_column(df: pl.DataFrame,
+                            col_name: str = "Txn Accounts") -> pl.DataFrame:
     """
     Add a column with the accounts involved in the transaction.
     """

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -175,7 +175,7 @@ def test_add_txn_accounts_colum():
                          "Checking | Salary", "Checking | Salary",
                          "Checking | Food", "Checking | Food", "Checking | Food"]
     }, schema={"Txn": pl.Int32, "Account short name": pl.Utf8, "Txn Accounts": pl.Utf8})
-    result = r.add_txn_accounts_colum(df)
+    result = r.add_txn_accounts_column(df)
 
     assert result.equals(expected)
 


### PR DESCRIPTION
### Fixed
- Fixed a typo in the report module. `add_txn_accounts_colum` -> `add_txn_accounts_column`